### PR TITLE
Purge old jobs

### DIFF
--- a/django_serverless_cron/management/commands/serverless_cron_purge.py
+++ b/django_serverless_cron/management/commands/serverless_cron_purge.py
@@ -1,5 +1,6 @@
 from django.core.management import BaseCommand
-from django_serverless_cron.models import JobRun
+
+from django_serverless_cron.services import purge_jobs
 
 
 class Command(BaseCommand):
@@ -11,8 +12,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         try:
             n = kwargs['n']
-            jobs = JobRun.objects.all().order_by('time_attempted_running')[:n]
-            jobs.delete()
+            purge_jobs(n)
             self.stdout.write(self.style.SUCCESS(f'Successfully purged the last {n} old jobs'))
         except Exception as e:
             self.stderr.write(self.style.ERROR(e))

--- a/django_serverless_cron/management/commands/serverless_cron_purge.py
+++ b/django_serverless_cron/management/commands/serverless_cron_purge.py
@@ -7,7 +7,7 @@ class Command(BaseCommand):
     help = "Deletes old jobs from the Database"
 
     def add_arguments(self, parser):
-        parser.add_argument('-n', type=int, help='Number of jobs to remove from the least recent to the most recent')
+        parser.add_argument('-n', type=int, help='Number of jobs to remove from the least recent')
 
     def handle(self, *args, **kwargs):
         try:

--- a/django_serverless_cron/management/commands/serverless_cron_purge.py
+++ b/django_serverless_cron/management/commands/serverless_cron_purge.py
@@ -1,0 +1,18 @@
+from django.core.management import BaseCommand
+from django_serverless_cron.models import JobRun
+
+
+class Command(BaseCommand):
+    help = "Deletes old jobs from the Database"
+
+    def add_arguments(self, parser):
+        parser.add_argument('-n', type=int, help='Number of jobs to remove from the least recent to the most recent')
+
+    def handle(self, *args, **kwargs):
+        try:
+            n = kwargs['n']
+            jobs = JobRun.objects.all().order_by('time_attempted_running')[:n]
+            jobs.delete()
+            self.stdout.write(self.style.SUCCESS(f'Successfully purged the last {n} old jobs'))
+        except Exception as e:
+            self.stderr.write(self.style.ERROR(e))

--- a/django_serverless_cron/management/commands/serverless_cron_purge.py
+++ b/django_serverless_cron/management/commands/serverless_cron_purge.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         try:
             n = kwargs['n']
-            purge_jobs(n)
+            purge_jobs(int(n))
             self.stdout.write(self.style.SUCCESS(f'Successfully purged the last {n} old jobs'))
         except Exception as e:
             self.stderr.write(self.style.ERROR(e))

--- a/django_serverless_cron/services.py
+++ b/django_serverless_cron/services.py
@@ -136,3 +136,11 @@ class RunJobs:
 
         for job in jobs:
             job.run()
+
+
+def purge_jobs(n):
+    """
+    Method executed for purging n number of jobs
+    """
+    jobs = JobRun.objects.all().order_by('time_attempted_running')[:n]
+    jobs.delete()

--- a/django_serverless_cron/services.py
+++ b/django_serverless_cron/services.py
@@ -138,9 +138,10 @@ class RunJobs:
             job.run()
 
 
-def purge_jobs(n):
+def purge_jobs(n: int):
     """
     Method executed for purging n number of jobs
     """
     jobs = JobRun.objects.all().order_by('time_attempted_running')[:n]
-    jobs.delete()
+    for job in jobs:
+        job.delete()

--- a/django_serverless_cron/urls.py
+++ b/django_serverless_cron/urls.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 
 
-from django.urls import re_path
-from .views import RunJobsView
+from django.urls import re_path, path
+from .views import RunJobsView, purge_jobs_view
 
 app_name = 'django_serverless_cron'
 urlpatterns = [
-    re_path(
-        "^run/$",
-        RunJobsView.as_view(),
-        name='django-serverless-cron-run-jobs'
-    ),
+    re_path("^run/$", RunJobsView.as_view(), name='django-serverless-cron-run-jobs'),
+    path("purge/<num>/", purge_jobs_view, name='django-serverless-cron-purge-jobs'),
 ]

--- a/django_serverless_cron/urls.py
+++ b/django_serverless_cron/urls.py
@@ -7,5 +7,5 @@ from .views import RunJobsView, purge_jobs_view
 app_name = 'django_serverless_cron'
 urlpatterns = [
     re_path("^run/$", RunJobsView.as_view(), name='django-serverless-cron-run-jobs'),
-    path("purge/<num>/", purge_jobs_view, name='django-serverless-cron-purge-jobs'),
+    path("purge/<int:n>/", purge_jobs_view, name='django-serverless-cron-purge-jobs'),
 ]

--- a/django_serverless_cron/views.py
+++ b/django_serverless_cron/views.py
@@ -16,14 +16,15 @@ class RunJobsView(View):
         return HttpResponse('Done')
 
 
-def purge_jobs_view(request, num):
-    n = request.GET.get(num)
-    if n is None:
+def purge_jobs_view(request, n):
+    if n is None or n == '':
         return HttpResponseBadRequest('You must supply the number of jobs to be purged.')
+
     try:
         purge_jobs(n)
-        return HttpResponse(f'Last {n} jobs Purged Successfully.')
     except Exception as e:
         logger.exception(e, exc_info=True)
         logger.error(e)
         HttpResponseServerError('An error occurred. Working to resolve the issue.')
+
+    return HttpResponse(f'Last {n} jobs Purged Successfully.')

--- a/django_serverless_cron/views.py
+++ b/django_serverless_cron/views.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+import logging
 
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseServerError, HttpResponseBadRequest
 from django.views import View
 
-from .services import RunJobs
+from .services import RunJobs, purge_jobs
+
+logger = logging.getLogger(__name__)
 
 
 class RunJobsView(View):
@@ -11,3 +14,16 @@ class RunJobsView(View):
     def get(self, request, *args, **kwargs):
         RunJobs.run_all_jobs()
         return HttpResponse('Done')
+
+
+def purge_jobs_view(request, num):
+    n = request.GET.get(num)
+    if n is None:
+        return HttpResponseBadRequest('You must supply the number of jobs to be purged.')
+    try:
+        purge_jobs(n)
+        return HttpResponse(f'Last {n} jobs Purged Successfully.')
+    except Exception as e:
+        logger.exception(e, exc_info=True)
+        logger.error(e)
+        HttpResponseServerError('An error occurred. Working to resolve the issue.')

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -11,8 +11,8 @@ Tests for `django_serverless_cron` management commands.
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from django_serverless_cron.management.commands.serverless_cron_run import \
-    Command
+from django_serverless_cron.management.commands.serverless_cron_run import Command as RunCommand
+from django_serverless_cron.management.commands.serverless_cron_purge import Command as PurgeCommand
 from django_serverless_cron.models import JobRun
 
 
@@ -25,7 +25,7 @@ class TestCommandServerlessCronRun(TestCase):
     ])
     def test_serverless_cron_run_command_handle(self):
         self.assertEqual(JobRun.objects.all().count(), 0)
-        command = Command()
+        command = RunCommand()
         command.handle(single_run=False)
         self.assertEqual(JobRun.objects.all().count(), 3)
 
@@ -36,6 +36,22 @@ class TestCommandServerlessCronRun(TestCase):
     ])
     def test_serverless_cron_run_command_handle_single_run(self):
         self.assertEqual(JobRun.objects.all().count(), 0)
-        command = Command()
+        command = RunCommand()
         command.handle(single_run=True)
         self.assertEqual(JobRun.objects.all().count(), 3)
+
+
+class TestCommandServerlessCronPurge(TestCase):
+    @override_settings(SERVERLESS_CRONJOBS=[
+        ('5_minutes', 'tests.example.jobs.example_job_1', {}),
+        ('1_minutes', 'tests.example.jobs.example_job_2', {}),
+        ('5_minutes', 'tests.example.jobs.example_job_2', {}),
+    ])
+    def test_serverless_cron_purge_handle_single_run(self):
+        self.assertEqual(JobRun.objects.all().exists(), False)
+        run_command = RunCommand()
+        run_command.handle(single_run=True)
+        self.assertEqual(JobRun.objects.all().exists(), True)
+        command = PurgeCommand()
+        command.handle(n=2)
+        self.assertEqual(JobRun.objects.all().count(), 1)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -12,7 +12,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from django_serverless_cron.models import JobRun
-from django_serverless_cron.services import Job, RunJobs
+from django_serverless_cron.services import Job, RunJobs, purge_jobs
 
 
 class TestJobs(TestCase):
@@ -62,3 +62,14 @@ class TestRunAllJobs(TestCase):
         self.assertEqual(JobRun.objects.all().count(), 0)
         RunJobs.run_all_jobs()
         self.assertEqual(JobRun.objects.all().count(), 2)
+
+
+class TestPurgeJobs(TestCase):
+    @override_settings(SERVERLESS_CRONJOBS=[
+        ('5_minutes', 'tests.example.jobs.example_job_1', {}),
+        ('1_minutes', 'tests.example.jobs.example_job_1', {}),
+    ])
+    def test_service_purge_jobs_purges(self):
+        RunJobs.run_all_jobs()
+        purge_jobs(1)
+        self.assertEqual(JobRun.objects.all().count(), 1)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -28,3 +28,22 @@ class TestRunJobsView(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(JobRun.objects.all().count(), 2)
+
+
+class TestPurgeJobsView(TestCase):
+    @override_settings(SERVERLESS_CRONJOBS=[
+        ('5_minutes', 'tests.example.jobs.example_job_1', {}),
+        ('1_minutes', 'tests.example.jobs.example_job_1', {}),
+    ])
+    def test_purge_jobs_view_purges_jobs(self):
+        self.assertEqual(JobRun.objects.all().count(), 0)
+        run_url = reverse("django_serverless_cron:django-serverless-cron-run-jobs")
+        run_response = self.client.get(run_url)
+
+        purge_url = reverse("django_serverless_cron:django-serverless-cron-purge-jobs", kwargs={'n': 1})
+        purge_response = self.client.get(purge_url)
+
+        self.assertEqual(run_response.status_code, 200)
+        self.assertEqual(purge_response.status_code, 200)
+
+        self.assertEqual(JobRun.objects.all().count(), 1)


### PR DESCRIPTION
- It  reaches a point where the DB is full of old `JobRun`s. 
- This feature implements 2 ways of purging/deleting said `JobRun`s.
    - Through management command using `python manage.py serverless_cron_purge -n 23`
    - Through `HTTP GET` request to `/purge/n/` where `n` is the number of last jobs to be deleted.
 - All tests have passed. 