### PR TITLE
Updating quickstart documentaton URL patterns example with re_path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,12 +101,13 @@ Add the jobs to your URL patterns:
 
 .. code-block:: python
 
+    from django.urls import path, re_path, include #add re_path and include
     from django_serverless_cron import urls as django_serverless_cron_urls
 
 
     urlpatterns = [
         # ...
-        url(r'^', include(django_serverless_cron_urls))
+        re_path(r'^', include(django_serverless_cron_urls)),
         #...
     ]
 


### PR DESCRIPTION
Small update to the quickstart documentation regarding url patterns: changing url to re_path.

Reason
* Since Django 2.0, the url() function is an alias to django.urls.re_path()
* url() is deprecated since Django 3.1